### PR TITLE
Adding Smaller Alpine based image

### DIFF
--- a/alpine-38.dockerfile
+++ b/alpine-38.dockerfile
@@ -14,7 +14,7 @@ ENV ROOT_ALIAS admin@example.com
 COPY ./etc/aliases /etc/aliases
 
 RUN apk update && \
- apk add postfix postfix-mysql rsyslog sed && \
+ apk add postfix postfix-mysql postfix-pcre rsyslog sed && \
  addgroup -S syslog && adduser -S -G syslog syslog
 
 # We disable IPv6 for now, IPv6 is available in Docker even if the host does not have IPv6 connectivity.

--- a/alpine-38.dockerfile
+++ b/alpine-38.dockerfile
@@ -1,4 +1,4 @@
-FROM tozd/runit:alpine
+FROM tozd/runit:alpine-38
 
 EXPOSE 25/tcp 465/tcp 587/tcp
 

--- a/alpine-38.dockerfile
+++ b/alpine-38.dockerfile
@@ -14,7 +14,7 @@ ENV ROOT_ALIAS admin@example.com
 COPY ./etc/aliases /etc/aliases
 
 RUN apk update && \
- apk add postfix rsyslog sed && \
+ apk add postfix postfix-mysql rsyslog sed && \
  addgroup -S syslog && adduser -S -G syslog syslog
 
 # We disable IPv6 for now, IPv6 is available in Docker even if the host does not have IPv6 connectivity.

--- a/alpine-38.dockerfile
+++ b/alpine-38.dockerfile
@@ -1,4 +1,4 @@
-FROM tozd/runit:ubuntu-bionic
+FROM tozd/runit:alpine
 
 EXPOSE 25/tcp 465/tcp 587/tcp
 
@@ -10,20 +10,17 @@ ENV MY_NETWORKS 172.17.0.0/16 127.0.0.0/8
 ENV MY_DESTINATION localhost.localdomain, localhost
 ENV ROOT_ALIAS admin@example.com
 
+RUN apk update && apk add postfix rsyslog sed
+
 # /etc/aliases should be available at postfix installation.
 COPY ./etc/aliases /etc/aliases
 
 # We disable IPv6 for now, IPv6 is available in Docker even if the host does not have IPv6 connectivity.
-RUN apt-get update -q -q && \
- echo postfix postfix/main_mailer_type string "'Internet Site'" | debconf-set-selections && \
- echo postfix postfix/mynetworks string "127.0.0.0/8" | debconf-set-selections && \
- echo postfix postfix/mailname string temporary.example.com | debconf-set-selections && \
- apt-get --yes --force-yes install postfix && \
+RUN addgroup -S syslog && adduser -S -G syslog syslog && \
  postconf -e mydestination="localhost.localdomain, localhost" && \
  postconf -e smtpd_banner='$myhostname ESMTP $mail_name' && \
  postconf -# myhostname && \
  postconf -e inet_protocols=ipv4 && \
- apt-get --yes --force-yes --no-install-recommends install rsyslog && \
- sed -i 's/\/var\/log\/mail/\/var\/log\/postfix\/mail/' /etc/rsyslog.d/50-default.conf
+ sed -i 's/\/var\/log\/mail/\/var\/log\/postfix\/mail/' /etc/rsyslog.conf
 
 COPY ./etc /etc

--- a/alpine-38.dockerfile
+++ b/alpine-38.dockerfile
@@ -10,14 +10,15 @@ ENV MY_NETWORKS 172.17.0.0/16 127.0.0.0/8
 ENV MY_DESTINATION localhost.localdomain, localhost
 ENV ROOT_ALIAS admin@example.com
 
-RUN apk update && apk add postfix rsyslog sed
-
 # /etc/aliases should be available at postfix installation.
 COPY ./etc/aliases /etc/aliases
 
+RUN apk update && \
+ apk add postfix rsyslog sed && \
+ addgroup -S syslog && adduser -S -G syslog syslog
+
 # We disable IPv6 for now, IPv6 is available in Docker even if the host does not have IPv6 connectivity.
-RUN addgroup -S syslog && adduser -S -G syslog syslog && \
- postconf -e mydestination="localhost.localdomain, localhost" && \
+RUN postconf -e mydestination="localhost.localdomain, localhost" && \
  postconf -e smtpd_banner='$myhostname ESMTP $mail_name' && \
  postconf -# myhostname && \
  postconf -e inet_protocols=ipv4 && \

--- a/etc/service/postfix/run
+++ b/etc/service/postfix/run
@@ -28,11 +28,11 @@ fi
 # openrc-run which is not supported by alpine very well, as the 
 # use on init systems is discouraged in general
 if [ -f /etc/alpine-release ]; then
-/usr/sbin/postfix -c /etc/postfix start >/dev/null 2>&1
-/usr/sbin/postfix -c /etc/postfix abort >/dev/null 2>&1
+  /usr/sbin/postfix -c /etc/postfix start >/dev/null 2>&1
+  /usr/sbin/postfix -c /etc/postfix abort >/dev/null 2>&1
 else
-/etc/init.d/postfix start
-/etc/init.d/postfix abort
+  /etc/init.d/postfix start
+  /etc/init.d/postfix abort
 fi
 
 # Is there any other script to run here?

--- a/etc/service/postfix/run
+++ b/etc/service/postfix/run
@@ -24,8 +24,16 @@ fi
 
 # We have to start and stop postfix first through init.d to populate
 # postfix spool directory for chroot in which postfix is running.
+# We do it a bit differently in alpine as the init.d scripts use
+# openrc-run which is not supported by alpine very well, as the 
+# use on init systems is discouraged in general
+if [ -f /etc/alpine-release ]; then
+/usr/sbin/postfix -c /etc/postfix start >/dev/null 2>&1
+/usr/sbin/postfix -c /etc/postfix abort >/dev/null 2>&1
+else
 /etc/init.d/postfix start
 /etc/init.d/postfix abort
+fi
 
 # Is there any other script to run here?
 [ -f /etc/service/postfix/run.initialization ] && source /etc/service/postfix/run.initialization

--- a/etc/service/rsyslog/run
+++ b/etc/service/rsyslog/run
@@ -6,4 +6,4 @@ rm -f /var/run/rsyslogd.pid
 mkdir -p /var/log/postfix
 chown syslog:syslog /var/log/postfix
 
-exec /usr/sbin/rsyslogd -n -c5 2>&1
+exec /usr/sbin/rsyslogd -n 2>&1

--- a/ubuntu-trusty.dockerfile
+++ b/ubuntu-trusty.dockerfile
@@ -1,4 +1,4 @@
-FROM tozd/runit:ubuntu-bionic
+FROM tozd/runit:ubuntu-trusty
 
 EXPOSE 25/tcp 465/tcp 587/tcp
 

--- a/ubuntu-trusty.dockerfile
+++ b/ubuntu-trusty.dockerfile
@@ -13,17 +13,18 @@ ENV ROOT_ALIAS admin@example.com
 # /etc/aliases should be available at postfix installation.
 COPY ./etc/aliases /etc/aliases
 
-# We disable IPv6 for now, IPv6 is available in Docker even if the host does not have IPv6 connectivity.
 RUN apt-get update -q -q && \
- echo postfix postfix/main_mailer_type string "'Internet Site'" | debconf-set-selections && \
+ apt-get --yes --force-yes install postfix && \
+ apt-get --yes --force-yes --no-install-recommends install rsyslog
+
+# We disable IPv6 for now, IPv6 is available in Docker even if the host does not have IPv6 connectivity.
+RUN echo postfix postfix/main_mailer_type string "'Internet Site'" | debconf-set-selections && \
  echo postfix postfix/mynetworks string "127.0.0.0/8" | debconf-set-selections && \
  echo postfix postfix/mailname string temporary.example.com | debconf-set-selections && \
- apt-get --yes --force-yes install postfix && \
  postconf -e mydestination="localhost.localdomain, localhost" && \
  postconf -e smtpd_banner='$myhostname ESMTP $mail_name' && \
  postconf -# myhostname && \
  postconf -e inet_protocols=ipv4 && \
- apt-get --yes --force-yes --no-install-recommends install rsyslog && \
  sed -i 's/\/var\/log\/mail/\/var\/log\/postfix\/mail/' /etc/rsyslog.d/50-default.conf
 
 COPY ./etc /etc


### PR DESCRIPTION
One major driving factor for creating this PR (Apart from smaller image size) is the version of postfix.
Alpine 3.8 has the postfix 3.3.x available in its package repo. while the ubuntu based image has 2.x AFAICT